### PR TITLE
Fixing a error in dismiss function

### DIFF
--- a/templates/notifications/toast/toast.js
+++ b/templates/notifications/toast/toast.js
@@ -73,7 +73,9 @@ fabric.Toast = function (timer) {
             // remove the toast object from the body when the animation completes
             setTimeout(function () {
                 var el = document.querySelector('#' + toast.id);
-                el.parentNode.removeChild(el);
+                if (el != null) {
+                    el.parentNode.removeChild(el);
+                }
             }, 300);
         }
     }


### PR DESCRIPTION
"el" may not be defined is the user dismissed the toast manually, so before removing it we must check its existence. Easy to reproduce : close the toast before it's automatically closed, you will see a js error.